### PR TITLE
Remove default sample image path

### DIFF
--- a/server.py
+++ b/server.py
@@ -11,8 +11,7 @@ def index():
     return "✅ Dummy server running"
 
 if __name__ == "__main__":
-    import sys
-    img_path = sys.argv[1] if len(sys.argv) > 1 else "vision/sample.png"
+    img_path = ""
     try:
         img = cv.imread(img_path)
         result = detect_card_in_slot(img, rank_templates, suit_templates)


### PR DESCRIPTION
## Summary
- Set an empty image path for the server without using the `sys` module

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5a56873a08322a0733569f9644d25