### PR TITLE
Add debug image output for OpenCV matches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 __pycache__/
 *.pyc
+match_debug.png

--- a/server.py
+++ b/server.py
@@ -15,6 +15,8 @@ if __name__ == "__main__":
     try:
         img = cv.imread(img_path)
         result = detect_card_in_slot(img, rank_templates, suit_templates)
+        if result["debug_img"] is not None:
+            cv.imwrite("match_debug.png", result["debug_img"])
         if result["card"]:
             print(f"Detected {result['card']} (confidence: {result['conf']:.2f})")
         else:

--- a/vision/cards.py
+++ b/vision/cards.py
@@ -14,28 +14,64 @@ def detect_card_in_slot(bgr_slot_mat, rank_tmps, suit_tmps):
     x, y, w, h = glyph_rect
     glyph = gray[y:y+h, x:x+w]
 
-    best_rank = {"name": None, "score": 0}
+    best_rank = {"name": None, "score": 0, "loc": None, "shape": None}
     for r in rank_tmps:
         t_gray = cv.cvtColor(r["mat"], cv.COLOR_BGR2GRAY)
         res = cv.matchTemplate(glyph, t_gray, cv.TM_CCOEFF_NORMED)
-        score = res.max()
+        _, score, _, loc = cv.minMaxLoc(res)
         if score > best_rank["score"]:
-            best_rank = {"name": r["name"], "score": score}
+            best_rank = {
+                "name": r["name"],
+                "score": score,
+                "loc": loc,
+                "shape": t_gray.shape[::-1],
+            }
 
-    best_suit = {"name": None, "score": 0}
+    best_suit = {"name": None, "score": 0, "loc": None, "shape": None}
     for s in suit_tmps:
         t_gray = cv.cvtColor(s["mat"], cv.COLOR_BGR2GRAY)
         res = cv.matchTemplate(glyph, t_gray, cv.TM_CCOEFF_NORMED)
-        score = res.max()
+        _, score, _, loc = cv.minMaxLoc(res)
         if score > best_suit["score"]:
-            best_suit = {"name": s["name"], "score": score}
+            best_suit = {
+                "name": s["name"],
+                "score": score,
+                "loc": loc,
+                "shape": t_gray.shape[::-1],
+            }
 
+    annotated = bgr_slot_mat.copy()
+    cv.rectangle(annotated, (x, y), (x + w, y + h), (0, 255, 0), 1)
+    if best_rank["loc"] and best_rank["shape"]:
+        rx, ry = best_rank["loc"]
+        rw, rh = best_rank["shape"]
+        cv.rectangle(
+            annotated,
+            (x + rx, y + ry),
+            (x + rx + rw, y + ry + rh),
+            (255, 0, 0),
+            1,
+        )
+    if best_suit["loc"] and best_suit["shape"]:
+        sx, sy = best_suit["loc"]
+        sw, sh = best_suit["shape"]
+        cv.rectangle(
+            annotated,
+            (x + sx, y + sy),
+            (x + sx + sw, y + sy + sh),
+            (0, 0, 255),
+            1,
+        )
+
+    result = {"card": None, "conf": 0, "debug_img": annotated}
     if (
         best_rank["score"] >= THRESH["matchMinScore"]
         and best_suit["score"] >= THRESH["matchMinScore"]
     ):
-        return {
-            "card": f"{best_rank['name']}-{best_suit['name']}",
-            "conf": min(best_rank["score"], best_suit["score"]),
-        }
-    return {"card": None, "conf": 0}
+        result.update(
+            {
+                "card": f"{best_rank['name']}-{best_suit['name']}",
+                "conf": min(best_rank["score"], best_suit["score"]),
+            }
+        )
+    return result

--- a/vision/recognize_card.py
+++ b/vision/recognize_card.py
@@ -12,6 +12,8 @@ def main():
     img_path = sys.argv[1]
     img = cv.imread(img_path)
     result = detect_card_in_slot(img, rank_templates, suit_templates)
+    if result["debug_img"] is not None:
+        cv.imwrite("match_debug.png", result["debug_img"])
     if result["card"]:
         print(f"Detected {result['card']} (confidence: {result['conf']:.2f})")
     else:


### PR DESCRIPTION
## Summary
- Track template match locations and return annotated debug image
- Save match_debug.png in recognizer and server
- Ignore match_debug.png to keep debug artifacts local

## Testing
- `python -m vision.recognize_card sample.png`
- `python test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6dc8f86a083229b8daaf7d874a72d