### PR TITLE
Scan each hand slot for card matches

### DIFF
--- a/server.py
+++ b/server.py
@@ -3,6 +3,8 @@ from flask import Flask
 import cv2 as cv
 from vision.templates import rank_templates, suit_templates
 from vision.cards import detect_card_in_slot
+from vision.config import ROI
+from vision.detect import map_roi
 
 app = Flask(__name__)
 
@@ -11,17 +13,26 @@ def index():
     return "✅ Dummy server running"
 
 if __name__ == "__main__":
-    img_path = "./sample.png "
+    img_path = "./sample.png"
     try:
         img = cv.imread(img_path)
-        result = detect_card_in_slot(img, rank_templates, suit_templates)
-        if result["debug_img"] is not None:
-            cv.imwrite("match_debug.png", result["debug_img"])
-        if result["card"]:
-            print(f"Detected {result['card']} (confidence: {result['conf']:.2f})")
-        else:
-            print("No card match found")
+        if img is None:
+            raise ValueError("Image data is empty")
+        shot_h, shot_w = img.shape[:2]
+        for idx, slot in enumerate(ROI.get("handSlots", [])):
+            x, y, w, h = map_roi(slot, shot_w, shot_h, 1920, 1080)
+            slot_img = img[y:y + h, x:x + w]
+            result = detect_card_in_slot(slot_img, rank_templates, suit_templates)
+            if result["debug_img"] is not None:
+                cv.imwrite(f"match_debug_{idx}.png", result["debug_img"])
+            if result["card"]:
+                print(
+                    f"Slot {idx}: Detected {result['card']} "
+                    f"(confidence: {result['conf']:.2f})"
+                )
+            else:
+                print(f"Slot {idx}: No card match found")
     except Exception as e:
-        print("Failed to read image:", img_path)
+        print("Failed to process image:", img_path)
         print(e)
     app.run(port=3000)

--- a/vision/config.py
+++ b/vision/config.py
@@ -16,7 +16,7 @@ ROI = {
 THRESH = {
     "greenHSV": {"low": [45, 80, 60], "high": [85, 255, 255]},
     "ocrPad": 4,
-    "matchMinScore": 0.6,
+    "matchMinScore": 0.5,
     "confirmFrames": 2,
     # Maximum allowed distance between the centers of the detected
     # rank and suit glyphs in pixels.  A larger separation implies the


### PR DESCRIPTION
## Summary
- Handle card recognition for each configured hand slot in sample images
- Lower template matching threshold to allow weaker matches

## Testing
- `python test.py`
- `python server.py` *(terminated with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e06c63fc83229e7ec71e6ee4e333