### PR TITLE
Add template matchers for remaining ranks and suits

### DIFF
--- a/vision/find_10.py
+++ b/vision/find_10.py
@@ -1,0 +1,36 @@
+import sys
+import cv2 as cv
+from .templates import rank_templates
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python -m vision.find_10 <image.png>")
+        return
+    img = cv.imread(sys.argv[1])
+    if img is None:
+        print(f"Could not read image {sys.argv[1]}")
+        return
+    template = next((t for t in rank_templates if t["name"] == "10"), None)
+    if template is None:
+        print("10 template not found")
+        return
+    gray_img = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
+    gray_tpl = cv.cvtColor(template["mat"], cv.COLOR_BGR2GRAY)
+    res = cv.matchTemplate(gray_img, gray_tpl, cv.TM_CCOEFF_NORMED)
+    _, max_val, _, max_loc = cv.minMaxLoc(res)
+    print(f"Best match score for 10: {max_val:.2f}")
+    threshold = 0.5
+    if max_val >= threshold:
+        h, w = gray_tpl.shape
+        top_left = max_loc
+        bottom_right = (top_left[0] + w, top_left[1] + h)
+        cv.rectangle(img, top_left, bottom_right, (0, 255, 0), 2)
+        cv.imwrite("10_match_debug.png", img)
+        print("10 found and annotated in 10_match_debug.png")
+    else:
+        print("10 not found")
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/find_a.py
+++ b/vision/find_a.py
@@ -1,0 +1,36 @@
+import sys
+import cv2 as cv
+from .templates import rank_templates
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python -m vision.find_a <image.png>")
+        return
+    img = cv.imread(sys.argv[1])
+    if img is None:
+        print(f"Could not read image {sys.argv[1]}")
+        return
+    template = next((t for t in rank_templates if t["name"] == "A"), None)
+    if template is None:
+        print("A template not found")
+        return
+    gray_img = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
+    gray_tpl = cv.cvtColor(template["mat"], cv.COLOR_BGR2GRAY)
+    res = cv.matchTemplate(gray_img, gray_tpl, cv.TM_CCOEFF_NORMED)
+    _, max_val, _, max_loc = cv.minMaxLoc(res)
+    print(f"Best match score for A: {max_val:.2f}")
+    threshold = 0.5
+    if max_val >= threshold:
+        h, w = gray_tpl.shape
+        top_left = max_loc
+        bottom_right = (top_left[0] + w, top_left[1] + h)
+        cv.rectangle(img, top_left, bottom_right, (0, 255, 0), 2)
+        cv.imwrite("a_match_debug.png", img)
+        print("A found and annotated in a_match_debug.png")
+    else:
+        print("A not found")
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/find_club.py
+++ b/vision/find_club.py
@@ -1,0 +1,36 @@
+import sys
+import cv2 as cv
+from .templates import suit_templates
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python -m vision.find_club <image.png>")
+        return
+    img = cv.imread(sys.argv[1])
+    if img is None:
+        print(f"Could not read image {sys.argv[1]}")
+        return
+    template = next((t for t in suit_templates if t["name"].lower() == "club"), None)
+    if template is None:
+        print("club template not found")
+        return
+    gray_img = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
+    gray_tpl = cv.cvtColor(template["mat"], cv.COLOR_BGR2GRAY)
+    res = cv.matchTemplate(gray_img, gray_tpl, cv.TM_CCOEFF_NORMED)
+    _, max_val, _, max_loc = cv.minMaxLoc(res)
+    print(f"Best match score for club: {max_val:.2f}")
+    threshold = 0.5
+    if max_val >= threshold:
+        h, w = gray_tpl.shape
+        top_left = max_loc
+        bottom_right = (top_left[0] + w, top_left[1] + h)
+        cv.rectangle(img, top_left, bottom_right, (0, 255, 0), 2)
+        cv.imwrite("club_match_debug.png", img)
+        print("club found and annotated in club_match_debug.png")
+    else:
+        print("club not found")
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/find_diamond.py
+++ b/vision/find_diamond.py
@@ -1,0 +1,36 @@
+import sys
+import cv2 as cv
+from .templates import suit_templates
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python -m vision.find_diamond <image.png>")
+        return
+    img = cv.imread(sys.argv[1])
+    if img is None:
+        print(f"Could not read image {sys.argv[1]}")
+        return
+    template = next((t for t in suit_templates if t["name"].lower() == "diamond"), None)
+    if template is None:
+        print("diamond template not found")
+        return
+    gray_img = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
+    gray_tpl = cv.cvtColor(template["mat"], cv.COLOR_BGR2GRAY)
+    res = cv.matchTemplate(gray_img, gray_tpl, cv.TM_CCOEFF_NORMED)
+    _, max_val, _, max_loc = cv.minMaxLoc(res)
+    print(f"Best match score for diamond: {max_val:.2f}")
+    threshold = 0.5
+    if max_val >= threshold:
+        h, w = gray_tpl.shape
+        top_left = max_loc
+        bottom_right = (top_left[0] + w, top_left[1] + h)
+        cv.rectangle(img, top_left, bottom_right, (0, 255, 0), 2)
+        cv.imwrite("diamond_match_debug.png", img)
+        print("diamond found and annotated in diamond_match_debug.png")
+    else:
+        print("diamond not found")
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/find_heart.py
+++ b/vision/find_heart.py
@@ -1,0 +1,36 @@
+import sys
+import cv2 as cv
+from .templates import suit_templates
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python -m vision.find_heart <image.png>")
+        return
+    img = cv.imread(sys.argv[1])
+    if img is None:
+        print(f"Could not read image {sys.argv[1]}")
+        return
+    template = next((t for t in suit_templates if t["name"].lower() == "heart"), None)
+    if template is None:
+        print("heart template not found")
+        return
+    gray_img = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
+    gray_tpl = cv.cvtColor(template["mat"], cv.COLOR_BGR2GRAY)
+    res = cv.matchTemplate(gray_img, gray_tpl, cv.TM_CCOEFF_NORMED)
+    _, max_val, _, max_loc = cv.minMaxLoc(res)
+    print(f"Best match score for heart: {max_val:.2f}")
+    threshold = 0.5
+    if max_val >= threshold:
+        h, w = gray_tpl.shape
+        top_left = max_loc
+        bottom_right = (top_left[0] + w, top_left[1] + h)
+        cv.rectangle(img, top_left, bottom_right, (0, 255, 0), 2)
+        cv.imwrite("heart_match_debug.png", img)
+        print("heart found and annotated in heart_match_debug.png")
+    else:
+        print("heart not found")
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/find_j.py
+++ b/vision/find_j.py
@@ -1,0 +1,36 @@
+import sys
+import cv2 as cv
+from .templates import rank_templates
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python -m vision.find_j <image.png>")
+        return
+    img = cv.imread(sys.argv[1])
+    if img is None:
+        print(f"Could not read image {sys.argv[1]}")
+        return
+    template = next((t for t in rank_templates if t["name"] == "J"), None)
+    if template is None:
+        print("J template not found")
+        return
+    gray_img = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
+    gray_tpl = cv.cvtColor(template["mat"], cv.COLOR_BGR2GRAY)
+    res = cv.matchTemplate(gray_img, gray_tpl, cv.TM_CCOEFF_NORMED)
+    _, max_val, _, max_loc = cv.minMaxLoc(res)
+    print(f"Best match score for J: {max_val:.2f}")
+    threshold = 0.5
+    if max_val >= threshold:
+        h, w = gray_tpl.shape
+        top_left = max_loc
+        bottom_right = (top_left[0] + w, top_left[1] + h)
+        cv.rectangle(img, top_left, bottom_right, (0, 255, 0), 2)
+        cv.imwrite("j_match_debug.png", img)
+        print("J found and annotated in j_match_debug.png")
+    else:
+        print("J not found")
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/find_k.py
+++ b/vision/find_k.py
@@ -1,0 +1,36 @@
+import sys
+import cv2 as cv
+from .templates import rank_templates
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python -m vision.find_k <image.png>")
+        return
+    img = cv.imread(sys.argv[1])
+    if img is None:
+        print(f"Could not read image {sys.argv[1]}")
+        return
+    template = next((t for t in rank_templates if t["name"] == "K"), None)
+    if template is None:
+        print("K template not found")
+        return
+    gray_img = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
+    gray_tpl = cv.cvtColor(template["mat"], cv.COLOR_BGR2GRAY)
+    res = cv.matchTemplate(gray_img, gray_tpl, cv.TM_CCOEFF_NORMED)
+    _, max_val, _, max_loc = cv.minMaxLoc(res)
+    print(f"Best match score for K: {max_val:.2f}")
+    threshold = 0.5
+    if max_val >= threshold:
+        h, w = gray_tpl.shape
+        top_left = max_loc
+        bottom_right = (top_left[0] + w, top_left[1] + h)
+        cv.rectangle(img, top_left, bottom_right, (0, 255, 0), 2)
+        cv.imwrite("k_match_debug.png", img)
+        print("K found and annotated in k_match_debug.png")
+    else:
+        print("K not found")
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/find_q.py
+++ b/vision/find_q.py
@@ -1,0 +1,36 @@
+import sys
+import cv2 as cv
+from .templates import rank_templates
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python -m vision.find_q <image.png>")
+        return
+    img = cv.imread(sys.argv[1])
+    if img is None:
+        print(f"Could not read image {sys.argv[1]}")
+        return
+    template = next((t for t in rank_templates if t["name"] == "Q"), None)
+    if template is None:
+        print("Q template not found")
+        return
+    gray_img = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
+    gray_tpl = cv.cvtColor(template["mat"], cv.COLOR_BGR2GRAY)
+    res = cv.matchTemplate(gray_img, gray_tpl, cv.TM_CCOEFF_NORMED)
+    _, max_val, _, max_loc = cv.minMaxLoc(res)
+    print(f"Best match score for Q: {max_val:.2f}")
+    threshold = 0.5
+    if max_val >= threshold:
+        h, w = gray_tpl.shape
+        top_left = max_loc
+        bottom_right = (top_left[0] + w, top_left[1] + h)
+        cv.rectangle(img, top_left, bottom_right, (0, 255, 0), 2)
+        cv.imwrite("q_match_debug.png", img)
+        print("Q found and annotated in q_match_debug.png")
+    else:
+        print("Q not found")
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/find_spade.py
+++ b/vision/find_spade.py
@@ -1,0 +1,36 @@
+import sys
+import cv2 as cv
+from .templates import suit_templates
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python -m vision.find_spade <image.png>")
+        return
+    img = cv.imread(sys.argv[1])
+    if img is None:
+        print(f"Could not read image {sys.argv[1]}")
+        return
+    template = next((t for t in suit_templates if t["name"].lower() == "spade"), None)
+    if template is None:
+        print("spade template not found")
+        return
+    gray_img = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
+    gray_tpl = cv.cvtColor(template["mat"], cv.COLOR_BGR2GRAY)
+    res = cv.matchTemplate(gray_img, gray_tpl, cv.TM_CCOEFF_NORMED)
+    _, max_val, _, max_loc = cv.minMaxLoc(res)
+    print(f"Best match score for spade: {max_val:.2f}")
+    threshold = 0.5
+    if max_val >= threshold:
+        h, w = gray_tpl.shape
+        top_left = max_loc
+        bottom_right = (top_left[0] + w, top_left[1] + h)
+        cv.rectangle(img, top_left, bottom_right, (0, 255, 0), 2)
+        cv.imwrite("spade_match_debug.png", img)
+        print("spade found and annotated in spade_match_debug.png")
+    else:
+        print("spade not found")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add rank matching scripts for Ace, Ten, Queen and Jack
- add suit matching scripts for diamond, heart and spade

## Testing
- `python -m vision.find_a sample.png`
- `python -m vision.find_q sample.png`
- `python -m vision.find_j sample.png`
- `python -m vision.find_10 sample.png`
- `python -m vision.find_diamond sample.png`
- `python -m vision.find_heart sample.png`
- `python -m vision.find_spade sample.png`
- `python -m vision.find_k sample.png`
- `python -m vision.find_club sample.png`
- `python test.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb31b4ae0083228e94bee38e04134c