### PR TITLE
Detect trump card in server sample run

### DIFF
--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ from vision.templates import rank_templates, suit_templates
 from vision.cards import detect_card_in_slot
 from vision.config import ROI
 from vision.detect import map_roi
+from vision.trump import detect_trump
 
 app = Flask(__name__)
 
@@ -19,6 +20,21 @@ if __name__ == "__main__":
         if img is None:
             raise ValueError("Image data is empty")
         shot_h, shot_w = img.shape[:2]
+
+        # Detect trump card
+        trump_slot = ROI.get("trumpSlot")
+        if trump_slot:
+            x, y, w, h = map_roi(trump_slot, shot_w, shot_h, 1920, 1080)
+            trump_img = img[y:y + h, x:x + w]
+            t_res = detect_trump(trump_img)
+            if t_res["rank"] and t_res["suit"]:
+                print(
+                    f"Trump: {t_res['rank']}-{t_res['suit']} "
+                    f"(confidence: {t_res['conf']:.2f})"
+                )
+            else:
+                print("Trump: No trump card match found")
+
         for idx, slot in enumerate(ROI.get("handSlots", [])):
             x, y, w, h = map_roi(slot, shot_w, shot_h, 1920, 1080)
             slot_img = img[y:y + h, x:x + w]


### PR DESCRIPTION
## Summary
- integrate trump card detection into the server's sample run
- log trump detection confidence alongside existing hand slot results

## Testing
- `python -m pytest`
- `python -m py_compile $(git ls-files '*.py')`
- `python server.py >/tmp/server.log 2>&1 &` (outputs trump and hand slot detections)


------
https://chatgpt.com/codex/tasks/task_e_68bffa2c09dc832291c9db2f50a2c703