### PR TITLE
Add detection for taken card counters

### DIFF
--- a/server.py
+++ b/server.py
@@ -24,6 +24,9 @@ if __name__ == "__main__":
         else:
             print("Trump: No trump card match found")
 
+        print(f"Taken by me: {state.get('takenMe', 0)}")
+        print(f"Taken by opponent: {state.get('takenOpp', 0)}")
+
         for slot in state["slots"]:
             idx = slot["slot"]
             if slot["debug_img"] is not None:

--- a/vision/scan.py
+++ b/vision/scan.py
@@ -3,19 +3,22 @@ from .cards import detect_card_in_slot
 from .config import ROI
 from .detect import map_roi
 from .trump_search import find_trump_card
+from .counters import match_counter
 
 
 def analyze_image(img):
-    """Detect trump card and cards in hand slots from a screenshot image.
+    """Detect trump card, taken counters, and hand slots from a screenshot.
 
     Args:
         img: BGR screenshot image.
 
     Returns:
-        dict with keys 'trump' and 'slots'.
+        dict with keys 'trump', 'slots', 'takenMe', and 'takenOpp'.
         'trump' is the result from ``find_trump_card``.
         'slots' is a list of dictionaries with keys 'slot', 'card', 'conf',
         and 'debug_img'.
+        'takenMe' and 'takenOpp' are integers representing how many cards
+        have been taken by the player and opponent respectively.
     """
     shot_h, shot_w = img.shape[:2]
 
@@ -33,4 +36,17 @@ def analyze_image(img):
             "debug_img": result["debug_img"],
         })
 
-    return {"trump": trump, "slots": slots}
+    taken_me = taken_opp = 0
+    if "takenMe" in ROI:
+        x, y, w, h = map_roi(ROI["takenMe"], shot_w, shot_h, 1920, 1080)
+        taken_me = match_counter(img[y:y + h, x:x + w])
+    if "takenOpp" in ROI:
+        x, y, w, h = map_roi(ROI["takenOpp"], shot_w, shot_h, 1920, 1080)
+        taken_opp = match_counter(img[y:y + h, x:x + w])
+
+    return {
+        "trump": trump,
+        "slots": slots,
+        "takenMe": taken_me,
+        "takenOpp": taken_opp,
+    }


### PR DESCRIPTION
## Summary
- detect taken card counters in screenshots
- expose taken counts in analyze_image and log them in server

## Testing
- `python test.py`
- `npm test` *(fails: Cannot find module 'vision/recognize-card.js')*


------
https://chatgpt.com/codex/tasks/task_e_68c1b8eb2bc88322b7892b6e4e1ecd6d