### PR TITLE
Display player and opponent scores

### DIFF
--- a/server.py
+++ b/server.py
@@ -3,6 +3,7 @@ from flask import Flask
 import cv2 as cv
 from vision.trump_search import find_trump_card
 from vision.scan import analyze_image
+from vision.score_search import find_scores
 
 app = Flask(__name__)
 
@@ -28,6 +29,10 @@ if __name__ == "__main__":
         state = analyze_image(img, trump=trump)
         print(f"Taken by me: {state.get('takenMe', 0)}")
         print(f"Taken by opponent: {state.get('takenOpp', 0)}")
+
+        scores = find_scores(img)
+        print(f"Score me: {scores['me']}")
+        print(f"Score opponent: {scores['opp']}")
 
         for slot in state["slots"]:
             idx = slot["slot"]

--- a/vision/score_search.py
+++ b/vision/score_search.py
@@ -1,0 +1,35 @@
+import os
+from .config import ROI, THRESH
+from .detect import map_roi
+from .find_score_me import match_score as _match_score_me
+from .find_score_opp import match_score as _match_score_opp
+
+
+def _extract_score(img, roi_def, matcher, pad, base_dir):
+    """Crop ROI from image and run the provided matcher."""
+    h, w = img.shape[:2]
+    x, y, rw, rh = map_roi(roi_def, w, h, w, h)
+    x = max(0, x - pad)
+    y = max(0, y - pad)
+    rw = min(rw + 2 * pad, w - x)
+    rh = min(rh + 2 * pad, h - y)
+    roi = img[y : y + rh, x : x + rw]
+    return matcher(roi, base_dir) or 0
+
+
+def find_scores(img, base_dir=None):
+    """Return detected scores for the player and opponent.
+
+    Args:
+        img: BGR screenshot image.
+        base_dir: Optional base directory for loading templates.
+
+    Returns:
+        dict with integer scores for keys 'me' and 'opp'.  If detection fails,
+        the score defaults to 0.
+    """
+    base_dir = base_dir or os.path.dirname(__file__)
+    pad = int(THRESH.get("ocrPad", 4))
+    score_me = _extract_score(img, ROI["scoreMe"], _match_score_me, pad, base_dir)
+    score_opp = _extract_score(img, ROI["scoreOpp"], _match_score_opp, pad, base_dir)
+    return {"me": score_me, "opp": score_opp}


### PR DESCRIPTION
## Summary
- move score detection into `vision.score_search` for cleaner ROI handling
- have `server.py` call `find_scores` and print player and opponent scores

## Testing
- `python test.py`
- `python server.py >/tmp/server.log &` then `tail -n 20 /tmp/server.log`


------
https://chatgpt.com/codex/tasks/task_e_68c5811157d08322b222fc682e9312ba