### PR TITLE
Fix base directory handling for score detection

### DIFF
--- a/vision/find_score_me.py
+++ b/vision/find_score_me.py
@@ -229,7 +229,7 @@ def match_score(bgr_roi_mat, base_dir, debug_dir=None):
         return v
 
     # Load templates (and log)
-    templates, tmpl_dir = _load_templates(os.path.dirname(__file__))
+    templates, tmpl_dir = _load_templates(base_dir)
     if debug_dir:
         with open(os.path.join(debug_dir, "templates_loaded.txt"), "w", encoding="utf-8") as f:
             f.write(f"template_dir={tmpl_dir}\n")


### PR DESCRIPTION
## Summary
- ensure `find_score_me.match_score` uses provided base directory for templates

## Testing
- `python -m py_compile vision/find_score_me.py`
- `python - <<'PY'
import cv2 as cv
from vision.score_search import find_scores
img=cv.imread('sample.png')
print(find_scores(img, base_dir='/tmp'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c5858c453c8322a5103582461f2342