### PR TITLE
Enforce confidence threshold for trump detection

### DIFF
--- a/vision/trump_search.py
+++ b/vision/trump_search.py
@@ -3,6 +3,9 @@ from .config import ROI
 from .detect import map_roi
 from .trump import detect_trump
 
+# Minimum confidence required to accept a detected trump card
+MIN_TRUMP_CONF = 0.9
+
 
 def find_trump_card(img):
     """Detect the trump card from a fixed slot on the screenshot.
@@ -31,4 +34,12 @@ def find_trump_card(img):
         if res["conf"] > best["conf"]:
             best = res
 
-    return {**best, "bbox": (x, y, rw, rh)}
+    result = {**best, "bbox": (x, y, rw, rh)}
+    if (
+        result["conf"] < MIN_TRUMP_CONF
+        or not result["rank"]
+        or not result["suit"]
+    ):
+        result["rank"] = None
+        result["suit"] = None
+    return result


### PR DESCRIPTION
## Summary
- Remove threshold handling from server and rely on `find_trump_card`
- Harden trump search to clear invalid results when rank or suit missing

## Testing
- `python test.py`
- `python - <<'PY'
import numpy as np
from vision.trump_search import find_trump_card
img = np.zeros((1080,1920,3), dtype='uint8')
res = find_trump_card(img)
print(res)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c58cf038b483228fef73722b66a777