### PR TITLE
Add doubling popup detection

### DIFF
--- a/server.py
+++ b/server.py
@@ -29,6 +29,7 @@ if __name__ == "__main__":
         state = analyze_image(img, trump=trump)
         print(f"Taken by me: {state.get('takenMe', 0)}")
         print(f"Taken by opponent: {state.get('takenOpp', 0)}")
+        print(f"Offered doubling: {state.get('hasOfferedDoubling', False)}")
 
         scores = find_scores(img)
         print(f"Score me: {scores['me']}")

--- a/vision/doubling_offer.py
+++ b/vision/doubling_offer.py
@@ -1,0 +1,30 @@
+import cv2 as cv
+from .config import ROI
+from .detect import map_roi
+
+
+def detect_doubling_popup(img):
+    """Return True if a black popup with text is present near the table center.
+
+    Args:
+        img: BGR screenshot image.
+
+    Returns:
+        bool indicating whether the doubling popup is detected.
+    """
+    shot_h, shot_w = img.shape[:2]
+    if "tableCenter" not in ROI:
+        return False
+
+    x, y, w, h = map_roi(ROI["tableCenter"], shot_w, shot_h, shot_w, shot_h)
+    roi = img[y : y + h, x : x + w]
+
+    gray = cv.cvtColor(roi, cv.COLOR_BGR2GRAY)
+    # Portion of dark pixels (background)
+    _, dark = cv.threshold(gray, 50, 255, cv.THRESH_BINARY_INV)
+    dark_ratio = cv.countNonZero(dark) / float(w * h)
+    # Portion of very bright pixels (text)
+    _, light = cv.threshold(gray, 200, 255, cv.THRESH_BINARY)
+    light_ratio = cv.countNonZero(light) / float(w * h)
+
+    return dark_ratio > 0.6 and light_ratio > 0.001

--- a/vision/find_doubling_offer.py
+++ b/vision/find_doubling_offer.py
@@ -1,0 +1,19 @@
+import sys
+import cv2 as cv
+from .doubling_offer import detect_doubling_popup
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python -m vision.find_doubling_offer <image.png>")
+        return
+    img = cv.imread(sys.argv[1])
+    if img is None:
+        print(f"Could not read image {sys.argv[1]}")
+        return
+    res = detect_doubling_popup(img)
+    print(f"hasOfferedDoubling: {res}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/scan.py
+++ b/vision/scan.py
@@ -4,6 +4,7 @@ from .config import ROI
 from .detect import map_roi
 from .trump_search import find_trump_card
 from .counters import match_counter
+from .doubling_offer import detect_doubling_popup
 
 
 def analyze_image(img, trump=None):
@@ -15,12 +16,13 @@ def analyze_image(img, trump=None):
             will be detected automatically.
 
     Returns:
-        dict with keys 'trump', 'slots', 'takenMe', and 'takenOpp'.
-        'trump' is the result from ``find_trump_card``.
-        'slots' is a list of dictionaries with keys 'slot', 'card', 'conf',
-        and 'debug_img'.
-        'takenMe' and 'takenOpp' are integers representing how many cards
-        have been taken by the player and opponent respectively.
+        dict with keys 'trump', 'slots', 'takenMe', 'takenOpp', and
+        'hasOfferedDoubling'.  'trump' is the result from
+        ``find_trump_card``.  'slots' is a list of dictionaries with keys
+        'slot', 'card', 'conf', and 'debug_img'.  'takenMe' and 'takenOpp'
+        are integers representing how many cards have been taken by the
+        player and opponent respectively.  'hasOfferedDoubling' is a bool
+        indicating whether a doubling popup is visible near the table center.
     """
     shot_h, shot_w = img.shape[:2]
 
@@ -46,9 +48,12 @@ def analyze_image(img, trump=None):
         x, y, w, h = map_roi(ROI["takenOpp"], shot_w, shot_h, shot_w, shot_h)
         taken_opp = match_counter(img[y:y + h, x:x + w])
 
+    has_offered_doubling = detect_doubling_popup(img)
+
     return {
         "trump": trump,
         "slots": slots,
         "takenMe": taken_me,
         "takenOpp": taken_opp,
+        "hasOfferedDoubling": has_offered_doubling,
     }


### PR DESCRIPTION
## Summary
- detect a dark doubling popup around the table center
- surface doubling status from analyze_image and server
- provide CLI helper to check images for doubling popup

## Testing
- `python -m vision.find_doubling_offer sample.png`
- `python test.py`


------
https://chatgpt.com/codex/tasks/task_e_68c670bc308483228b867d9e8c16bccd